### PR TITLE
fix: incorrect bash path in generated `.cmd` files

### DIFF
--- a/Argcfile.sh
+++ b/Argcfile.sh
@@ -205,9 +205,9 @@ _build_win_shim() {
     lang="$1"
     cmd="$(_lang_to_cmd "$lang")"
     if [[ "$lang" == "sh" ]]; then
-        run="\"$(cygpath -w "$(which $cmd)")\" --noprofile --norc"
+        run="\"$(argc --argc-shell-path)\" --noprofile --norc"
     else
-        run="\"$(cygpath -w "$(which $cmd)")\""
+        run="\"$(_normalize_path "$(which $cmd)")\""
     fi
     cat <<-EOF
 @echo off


### PR DESCRIPTION
The bash path is incorrect, so when I run the command script, it throws an error.
```
C:\w\llm-functions\cmd\cmd.sh: line 19: cygpath: command not found
```

This pr fixs this bug.
```diff
-- "C:\Program Files\Git\usr\bin\bash.exe"
++ "C:\Program Files\Git\bin\bash.exe"
```