### PR TITLE
feat: agent rag use `documents` field other than `embeddings` dir

### DIFF
--- a/Argcfile.sh
+++ b/Argcfile.sh
@@ -235,7 +235,7 @@ build-bin@agent() {
                 echo "Build agent $name"
             fi
         done
-        if [[ "$found" = "false" ]]; then
+        if [[ "$found" == "false" ]] && [[ ! -d "$agent_dir"  ]]; then
             not_found_agents+=("$name")
         fi
     done
@@ -276,7 +276,7 @@ build-declarations@agent() {
                 echo "$json_data" > "$declarations_file"
             fi
         done
-        if [[ "$found" == "false" ]]; then
+        if [[ "$found" == "false" ]] && [[ ! -d "$agent_dir"  ]]; then
             not_found_agents+=("$name")
         fi
     done

--- a/README.md
+++ b/README.md
@@ -130,7 +130,6 @@ The agent has the following folder structure:
 ```
 └── agents
     └── myagent
-        ├── embeddings/                     # Contains RAG files for knowledge
         ├── functions.json                  # Function declarations file (Auto-generated)
         ├── index.yaml                      # Agent definition file
         └── tools.{sh,js,py}                # Agent tools script
@@ -145,6 +144,8 @@ version: v0.1.0
 instructions: You are a test ai agent to ... 
 conversation_starters:
   - What can you do?
+documents:
+  - files/doc.pdf
 ```
 
 Refer to `./agents/todo-{sh,js,py}` for examples of how to implement a agent.


### PR DESCRIPTION
Instead of useing `embeddings` dir, we add `documents` field to agent definition file `index.yaml`.

```diff
# agent/index.yaml
documents:
  - files/doc.pdf
```