### PR TITLE
feat: prompt confirmation for fs write operations outside cwd

### DIFF
--- a/tools/fs_cat.sh
+++ b/tools/fs_cat.sh
@@ -4,12 +4,10 @@ set -e
 # @describe Read the contents of a file at the specified path.
 # Use this when you need to examine the contents of an existing file.
 
-# @env FS_BASE_DIR=. The base dir
 # @option --path! The path of the file to read
 
 main() {
-    path="$FS_BASE_DIR/$argc_path"
-    cat "$path" >> "$LLM_OUTPUT"
+    cat "$argc_path" >> "$LLM_OUTPUT"
 }
 
 eval "$(argc --argc-eval "$0" "$@")"

--- a/tools/fs_ls.sh
+++ b/tools/fs_ls.sh
@@ -3,12 +3,10 @@ set -e
 
 # @describe List all files and directories at the specified path.
 
-# @env FS_BASE_DIR=. The base dir
 # @option --path! The path of the directory to list
 
 main() {
-    path="$FS_BASE_DIR/$argc_path"
-    ls -1 "$path" >> "$LLM_OUTPUT"
+    ls -1 "$argc_path" >> "$LLM_OUTPUT"
 }
 
 eval "$(argc --argc-eval "$0" "$@")"

--- a/tools/fs_mkdir.sh
+++ b/tools/fs_mkdir.sh
@@ -3,13 +3,11 @@ set -e
 
 # @describe Create a new directory at the specified path.
 
-# @env FS_BASE_DIR=. The base dir
 # @option --path! The path of the directory to create
 
 main() {
-    path="$FS_BASE_DIR/$argc_path"
-    mkdir -p "$path"
-    echo "Directory created: $path" >> "$LLM_OUTPUT"
+    mkdir -p "$argc_path"
+    echo "Directory created: $argc_path" >> "$LLM_OUTPUT"
 }
 
 eval "$(argc --argc-eval "$0" "$@")"

--- a/tools/fs_rm.sh
+++ b/tools/fs_rm.sh
@@ -7,9 +7,25 @@ set -e
 # @option --path! The path of the file or directory to remove
 
 main() {
-    path="$FS_BASE_DIR/$argc_path"
-    rm -rf "$path"
-    echo "Path removed: $path" >> "$LLM_OUTPUT"
+    if [[ -f "$argc_path" ]]; then
+        _guard_path "$argc_path" Remove
+        rm -rf "$argc_path"
+    fi
+    echo "Path removed: $argc_path" >> "$LLM_OUTPUT"
+}
+
+_guard_path() {
+    path="$(realpath "$1")"
+    action="$2"
+    if [[ ! "$path" == "$(pwd)"* ]]; then
+        if [ -t 1 ]; then
+            read -r -p "$action $path? [Y/n] " ans
+            if [[ "$ans" == "N" || "$ans" == "n" ]]; then
+                echo "Aborted!"
+                exit 1
+            fi
+        fi
+    fi
 }
 
 eval "$(argc --argc-eval "$0" "$@")"

--- a/tools/fs_write.sh
+++ b/tools/fs_write.sh
@@ -6,15 +6,28 @@ set -e
 # If the file doesn't exist, it will be created.
 # Always provide the full intended contents of the file.
 
-# @env FS_BASE_DIR=. The base dir
 # @option --path! The path of the file to write to
 # @option --contents! The full contents to write to the file
 
 main() {
-    path="$FS_BASE_DIR/$argc_path"
-    mkdir -p "$(dirname "$path")"
-    printf "%s" "$argc_contents" > "$path"
-    echo "The contents written to: $path" >> "$LLM_OUTPUT"
+    _guard_path "$argc_path" Write
+    mkdir -p "$(dirname "$argc_path")"
+    printf "%s" "$argc_contents" > "$argc_path"
+    echo "The contents written to: $argc_path" >> "$LLM_OUTPUT"
+}
+
+_guard_path() {
+    path="$(realpath "$1")"
+    action="$2"
+    if [[ ! "$path" == "$(pwd)"* ]]; then
+        if [ -t 1 ]; then
+            read -r -p "$action $path? [Y/n] " ans
+            if [[ "$ans" == "N" || "$ans" == "n" ]]; then
+                echo "Aborted!"
+                exit 1
+            fi
+        fi
+    fi
 }
 
 eval "$(argc --argc-eval "$0" "$@")"


### PR DESCRIPTION
`FS_BASE_DIR`  does not work properly, see https://github.com/sigoden/llm-functions/pull/70#issuecomment-2265198017

We are changing to a new security policy:

- Always allow read operations.
- Always allow write operations that only affect the current directory.
- For other operations, prompt for confirmation.

![image](https://github.com/user-attachments/assets/93a11ecd-e13c-414b-bce0-e99ad0809792)
