### PR TITLE
feat: controls displaying the results from function call

### DIFF
--- a/scripts/run-agent.py
+++ b/scripts/run-agent.py
@@ -11,7 +11,7 @@ def main():
     agent_data = parse_raw_data(raw_data)
 
     root_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
-    setup_env(root_dir, agent_name)
+    setup_env(root_dir, agent_name, agent_func)
 
     agent_tools_path = os.path.join(root_dir, f"agents/{agent_name}/tools.py")
     run(agent_tools_path, agent_func, agent_data)
@@ -49,10 +49,11 @@ def parse_argv(this_file_name):
     return agent_name, agent_func, agent_data
 
 
-def setup_env(root_dir, agent_name):
+def setup_env(root_dir, agent_name, agent_func):
     load_env(os.path.join(root_dir, ".env"))
     os.environ["LLM_ROOT_DIR"] = root_dir
     os.environ["LLM_AGENT_NAME"] = agent_name
+    os.environ["LLM_AGENT_FUNC"] = agent_func
     os.environ["LLM_AGENT_ROOT_DIR"] = os.path.join(root_dir, "agents", agent_name)
     os.environ["LLM_AGENT_CACHE_DIR"] = os.path.join(root_dir, "cache", agent_name)
 
@@ -86,6 +87,42 @@ def run(agent_path, agent_func, agent_data):
 
     value = getattr(mod, agent_func)(**agent_data)
     return_to_llm(value)
+    dump_result()
+
+
+def dump_result():
+    if not os.isatty(1):
+        return
+
+    if not os.getenv("LLM_OUTPUT"):
+        return
+
+    show_result = False
+    agent_name = os.environ["LLM_AGENT_NAME"].upper().replace("-", "_")
+    agent_env_name = f"LLM_AGENT_DUMP_RESULT_{agent_name}"
+    agent_env_value = os.getenv(agent_env_name)
+
+    func_name = os.environ["LLM_AGENT_FUNC"].upper().replace("-", "_")
+    func_env_name = f"{agent_env_name}_{func_name}"
+    func_env_value = os.getenv(func_env_name)
+
+    if agent_env_value in ("1", "true"):
+        if func_env_value not in ("0", "false"):
+            show_result = True
+    else:
+        if func_env_value in ("1", "true"):
+            show_result = True
+
+    if not show_result:
+        return
+
+    try:
+        with open(os.environ["LLM_OUTPUT"], "r", encoding="utf-8") as f:
+            data = f.read()
+    except:
+        return
+
+    print(f"\x1b[2m----------------------\n{data}\n----------------------\x1b[0m")
 
 
 def return_to_llm(value):
@@ -107,4 +144,8 @@ def return_to_llm(value):
 
 
 if __name__ == "__main__":
-    main()
+    try:
+        main()
+    except Exception as e:
+        print(e, file=sys.stderr)
+        sys.exit(1)

--- a/scripts/run-tool.py
+++ b/scripts/run-tool.py
@@ -82,6 +82,7 @@ def run(tool_path, tool_func, tool_data):
 
     value = getattr(mod, tool_func)(**tool_data)
     return_to_llm(value)
+    dump_result()
 
 
 def return_to_llm(value):
@@ -100,6 +101,37 @@ def return_to_llm(value):
         value_str = json.dumps(value, indent=2)
         assert value == json.loads(value_str)
         writer.write(value_str)
+
+
+def dump_result():
+    if not os.isatty(1):
+        return
+
+    if not os.getenv("LLM_OUTPUT"):
+        return
+
+    show_result = False
+    tool_name = os.environ["LLM_TOOL_NAME"].upper().replace("-", "_")
+    env_name = f"LLM_TOOL_DUMP_RESULT_{tool_name}"
+    env_value = os.getenv(env_name)
+
+    if os.getenv("LLM_TOOL_DUMP_RESULT") in ("1", "true"):
+        if env_value not in ("0", "false"):
+            show_result = True
+    else:
+        if env_value in ("1", "true"):
+            show_result = True
+
+    if not show_result:
+        return
+
+    try:
+        with open(os.environ["LLM_OUTPUT"], "r", encoding="utf-8") as f:
+            data = f.read()
+    except:
+        return
+
+    print(f"\x1b[2m----------------------\n{data}\n----------------------\x1b[0m")
 
 
 if __name__ == "__main__":

--- a/scripts/run-tool.sh
+++ b/scripts/run-tool.sh
@@ -88,7 +88,35 @@ EOF
     eval "'$tool_path' $args"
     if [[ "$no_llm_output" -eq 1 ]]; then
         cat "$LLM_OUTPUT"
+    else
+        dump_result
     fi
+}
+
+dump_result() {
+    if [ ! -t 1 ]; then
+        return;
+    fi
+    local env_name env_value show_result=0
+    env_name="LLM_TOOL_DUMP_RESULT_$(echo "$LLM_TOOL_NAME" | tr '[:lower:]' '[:upper:]' | tr '-' '_')"
+    env_value="${!env_name}"
+    if [[ "$LLM_TOOL_DUMP_RESULT" == "1" || "$LLM_TOOL_DUMP_RESULT" == "true" ]]; then
+        if [[ "$env_value" != "0" && "$env_value" != "false" ]]; then
+            show_result=1
+        fi
+    else
+        if [[ "$env_value" == "1" || "$env_value" == "true" ]]; then
+            show_result=1
+        fi
+    fi
+    if [[ "$show_result" -ne 1 ]]; then
+        return
+    fi
+    cat <<EOF
+$(echo -e "\e[2m")----------------------
+$(cat "$LLM_OUTPUT")
+----------------------$(echo -e "\e[0m")
+EOF
 }
 
 die() {


### PR DESCRIPTION
 We use environment variables to control this.

`LLM_TOOL_DUMP_RESULT=1`: Dump results from all tools.
`LLM_TOOL_DUMP_RESULT_<TOOL_NAME>=1`: Dump result from the `TOOL_NAME` tool.
`LLM_AGENT_DUMP_RESULT_<AGENT_NAME>=1`: Dump results from all tools of the `AGENT_NAME` agent.
`LLM_AGENT_DUMP_RESULT_<AGENT_NAME>_<FN_NAME>=1`: Dump results from the `FN_NAME` tool of the `AGENT_NAME` agent.

![image](https://github.com/user-attachments/assets/5df4e548-0b7f-499e-a541-dfdf045deeb5)

close #110
