### PR TITLE
feat: support python virtualenv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,7 @@ functions.json
 /tools/code_interpreter.*
 /.env
 __pycache__
-/venv
+/.venv
 node_modules
 /package.json
 /package-lock.json


### PR DESCRIPTION
After the PR merged, llm-functions will works with python virtualenv. 

The only thing you need to do is make sure the virtualenv path is `.venv`. Users can set up the venv using the following command.

```
python -m venv .venv
```

close #115 