### PR TITLE
refactor: git ignore all tools/agents startsWith `_`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,8 @@
 functions.json
 /bin
 /cache
-/tools/test.*
+/agents/_*
+/tools/_*
 /tools/web_search.*
 /tools/code_interpreter.*
 /.env

--- a/Argcfile.sh
+++ b/Argcfile.sh
@@ -500,8 +500,9 @@ install() {
 }
 
 # @cmd Create a boilplate tool script
+# @alias tool:create
 # @arg args~
-create() {
+create@tool() {
     ./scripts/create-tool.sh "$@"
 }
 

--- a/scripts/build-declarations.sh
+++ b/scripts/build-declarations.sh
@@ -17,7 +17,14 @@ main() {
 }
 
 build_declarations() {
-    jq -r '
+    jq --arg is_tool "$is_tool" -r '
+    def filter_declaration:
+        (if $is_tool == "true" then
+            .
+        else
+            select(.name | startswith("_") | not) 
+        end) | select(.description != "");
+
     def parse_description(flag_option):
         if flag_option.describe == "" then
             {}
@@ -59,7 +66,7 @@ build_declarations() {
             parameters: parse_parameter([.flag_options[] | select(.id != "help" and .id != "version")])
         };
     [
-        .[] | parse_declaration | select(.name | startswith("_") | not) | select(.description != "")
+        .[] | parse_declaration | filter_declaration
     ]'
 }
 

--- a/scripts/create-tool.sh
+++ b/scripts/create-tool.sh
@@ -4,9 +4,9 @@ set -e
 # @describe Create a boilplate tool script
 #
 # Examples:
-#   argc create test.sh foo bar! baz+ qux*
-#   ./scripts/create-tool.sh test.py foo bar! baz+ qux*
+#   ./scripts/create-tool.sh _test.py foo bar! baz+ qux*
 #
+# @option --description <text> The tool description
 # @flag --force Override the exist tool file
 # @arg name! The script file name.
 # @arg params* The script parameters
@@ -17,6 +17,7 @@ main() {
         _die "$output already exists"
     fi
     ext="${argc_name##*.}"
+    description="${argc_description:-"The description for the tool"}"
     support_exts=('.sh' '.js' '.py')
     if [[ "$ext" == "$argc_name" ]]; then
         _die "error: no extension name, pelease add one of ${support_exts[*]}" 
@@ -31,12 +32,12 @@ main() {
 }
 
 create_sh() {
-    cat <<-'EOF' | sed 's/__DESCRIBE_TAG__/# @describe/g' > "$output"
+    cat <<-'EOF' > "$output"
 #!/usr/bin/env bash
 set -e
 
-__DESCRIBE_TAG__
 EOF
+    echo "# @describe $description" >> "$output"
     for param in "${argc_params[@]}"; do
         echo "# @option --$(echo $param | sed 's/-/_/g')" >> "$output"
     done
@@ -70,7 +71,7 @@ create_js() {
     done
     cat <<EOF > "$output"
 /**
- *
+ * ${description}
  * @typedef {Object} Args${properties}
  * @param {Args} args
  */
@@ -132,8 +133,8 @@ create_py() {
     fi
     cat <<EOF > "$output"
 ${imports}
-def main(${required_arguments}${optional_arguments}):
-    """
+def run(${required_arguments}${optional_arguments}):
+    """${description}
     Args:${required_properties}${optional_properties}
     """
     pass


### PR DESCRIPTION
So that we can create private tools/agents that do not need to be submitted to the git repo.