### PR TITLE
fix: git bash on windows backslashs bug

### DIFF
--- a/scripts/run-agent.sh
+++ b/scripts/run-agent.sh
@@ -62,6 +62,7 @@ run() {
     if [[ "$OS" == "Windows_NT" ]]; then
         set -o igncr
         tools_path="$(cygpath -w "$tools_path")"
+        tool_data="$(echo "$tool_data" | sed 's/\\/\\\\/g')"
     fi
 
     jq_script="$(cat <<-'EOF'

--- a/scripts/run-mcp-tool.sh
+++ b/scripts/run-mcp-tool.sh
@@ -44,6 +44,15 @@ load_env() {
 }
 
 run() {
+    if [[ -z "$tool_data" ]]; then
+        die "error: no JSON data"
+    fi
+
+    if [[ "$OS" == "Windows_NT" ]]; then
+        set -o igncr
+        tool_data="$(echo "$tool_data" | sed 's/\\/\\\\/g')"
+    fi
+
     no_llm_output=0
     if [[ -z "$LLM_OUTPUT" ]]; then
         no_llm_output=1

--- a/scripts/run-tool.sh
+++ b/scripts/run-tool.sh
@@ -58,6 +58,7 @@ run() {
     if [[ "$OS" == "Windows_NT" ]]; then
         set -o igncr
         tool_path="$(cygpath -w "$tool_path")"
+        tool_data="$(echo "$tool_data" | sed 's/\\/\\\\/g')"
     fi
 
     jq_script="$(cat <<-'EOF'


### PR DESCRIPTION
Git bash for windows does not handle slashes correctly, it converts double slashes to single slash for json.

The command to inspect the bug.
```
PS> & 'C:\Program Files\Git\usr\bin\bash.exe' dump.sh '{"path":"C:\\file"}'
{"path":"C:\file"}
```
The contect of `dump.sh`.
```sh
printf "%s\n" "$@"
```

This PR replaces single blackslash to double blackslashs to avoid the bug.