### PR TITLE
feat(mcp): add `prefix` filed to  bridge server configuraiton

### DIFF
--- a/mcp/bridge/README.md
+++ b/mcp/bridge/README.md
@@ -4,7 +4,7 @@ Let external MCP tools be used by LLM-Functions.
 
 ## Get Started
 
-1. Create a `mpc.json` at `<llm-functions-dir>`.
+### 1. Create a `mpc.json` at `<llm-functions-dir>`.
 
 ```json
 {
@@ -16,6 +16,15 @@ Let external MCP tools be used by LLM-Functions.
         "--db-path",
         "/tmp/foo.db"
       ]
+    },
+    "git": {
+      "command": "uvx",
+      "args": [
+        "mcp-server-git",
+        "--repository",
+        "path/to/git/repo"
+      ],
+      "prefix": false
     },
     "github": {
       "command": "npx",
@@ -31,9 +40,11 @@ Let external MCP tools be used by LLM-Functions.
 }
 ```
 
-> MCP-Bridge will launch the server and register all the tools listed by the server. The tool identifier will be `server_toolname` to avoid clashes.
+> MCP-Bridge will launch the server and register all the tools listed by the server. 
 
-2. Run the bridge server, build mcp tool binaries, update functions.json, all with:
+> To avoid name clashes, The server automatically prefix tool names with `<server>_`. You can disable this behavior by add `prefix: false` to server configuration.
+
+### 2. Run the bridge server, build mcp tool binaries, update functions.json, all with:
 
 ```
 argc mcp start

--- a/mcp/bridge/index.js
+++ b/mcp/bridge/index.js
@@ -29,8 +29,9 @@ try {
 async function startMcpServer(id, serverConfig) {
   console.log(`Starting ${id} server...`);
   const capabilities = { tools: {} };
+  const { prefix = true, ...rest } = serverConfig;
   const transport = new StdioClientTransport({
-    ...serverConfig,
+    ...rest,
   });
   const client = new Client(
     { name: id, version: "1.0.0" },
@@ -42,7 +43,7 @@ async function startMcpServer(id, serverConfig) {
     ({ name, description, inputSchema }) =>
     ({
       spec: {
-        name: `${normalizeToolName(`${id}_${name}`)}`,
+        name: `${formatToolName(id, name, prefix)}`,
         description,
         parameters: inputSchema,
       },
@@ -181,7 +182,8 @@ function arrayify(a) {
   return r
 }
 
-function normalizeToolName(name) {
+function formatToolName(serverName, toolName, prefix) {
+  const name = prefix ? `${serverName}_${toolName}` : toolName;
   return name.toLowerCase().replace(/-/g, "_");
 }
 


### PR DESCRIPTION
To avoid name clashes, The server automatically prefix tool names with `<server>_`. You can disable this behavior by add `prefix: false` to server configuration.