### PR TITLE
feat(mcp): add LLM_MCP_NEED_CONFIRM and LLM_MCP_SKIP_CONFIRM

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -21,6 +21,8 @@
 
 ## Provided by users
 
-| Name               | Description                                                                                   |
-| ------------------ | --------------------------------------------------------------------------------------------- |
-| `LLM_DUMP_RESULTS` | Controls whether to print the execution results of the tool, e.g. `get_current_weather\|fs.*\|todo:.*`, `.*` |
+| Name                   | Description                                                                                                  |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------ |
+| `LLM_DUMP_RESULTS`     | Controls whether to print the execution results of the tool, e.g. `get_current_weather\|fs.*\|todo:.*`, `.*` |
+| `LLM_MCP_NEED_CONFIRM`| Controls whether to prompt for confirmation before executing certain tools, e.g., `git_commit\|git_reset`, `.*` . |
+| `LLM_MCP_SKIP_CONFIRM`| Controls whether to bypass confirmation requests for certain tools, e.g., `git_status\|git_diff.*`, `.*` . |

--- a/scripts/run-mcp-tool.sh
+++ b/scripts/run-mcp-tool.sh
@@ -60,6 +60,25 @@ run() {
         is_temp_llm_output=1
         export LLM_OUTPUT="$(mktemp)"
     fi
+
+    if [[ -n "$LLM_MCP_SKIP_CONFIRM" ]]; then
+        if grep -q -w -E "$LLM_MCP_SKIP_CONFIRM" <<<"$tool_name"; then
+            skip_confirm=1
+        fi
+    fi
+    if [[ -n "$LLM_MCP_NEED_CONFIRM" ]]; then
+        if grep -q -w -E "$LLM_MCP_NEED_CONFIRM" <<<"$tool_name"; then
+            skip_confirm=0
+        fi
+    fi
+    if [[ -t 1 ]] && [[ "$skip_confirm" -ne 1 ]]; then
+        read -r -p "Are you sure you want to continue? [Y/n] " ans
+        if [[ "$ans" == "N" || "$ans" == "n" ]]; then
+            echo "error: canceld!" 2>&1
+            exit 1
+        fi
+    fi
+
     curl -sS "http://localhost:${MCP_BRIDGE_PORT:-8808}/tools/$tool_name" \
         -X POST \
         -H 'content-type: application/json' \


### PR DESCRIPTION
By default, llm-functions will ask confirm before executing the mcp tools.

### `LLM_MCP_NEED_CONFIRM`
Controls whether to prompt for confirmation before executing certain tools, e.g., `git_commit\|git_reset`, `.*` 

### `LLM_MCP_SKIP_CONFIRM`
Controls whether to bypass confirmation requests for certain tools, e.g., `git_status\|git_diff.*`, `.*` 

