### PR TITLE
refactor(mcp): change to `mcp: <name>` for mcp tool declarations

### DIFF
--- a/mcp/bridge/index.js
+++ b/mcp/bridge/index.js
@@ -46,6 +46,7 @@ async function startMcpServer(id, serverConfig) {
         name: `${formatToolName(id, name, prefix)}`,
         description,
         parameters: inputSchema,
+        mcp: id,
       },
       impl: async args => {
         const res = await client.callTool({

--- a/scripts/mcp.sh
+++ b/scripts/mcp.sh
@@ -22,7 +22,7 @@ start() {
         index_js="$(cygpath -w "$index_js")"
         llm_functions_dir="$(cygpath -w "$llm_functions_dir")"
     fi
-    echo "Run MCP Bridge server"
+    echo "Start MCP Bridge server..."
     nohup node  "$index_js" "$llm_functions_dir" > "$MCP_DIR/mcp-bridge.log" 2>&1 &
     wait-for-server
     echo "Merge MCP tools into functions.json"
@@ -114,7 +114,7 @@ recovery-functions() {
 
 # @cmd Generate function declarations for the mcp tools
 generate-declarations() {
-    curl -sS http://localhost:$MCP_BRIDGE_PORT/tools | jq '.[] |= . + {mcp: true}'
+    curl -sS http://localhost:$MCP_BRIDGE_PORT/tools
 }
 
 # @cmd Wait for the mcp bridge server to ready


### PR DESCRIPTION
```diff
...
{
    "name": "fs_read_file",
    "description": "Read the complete contents of a file from the file system. Handles various text encodings and provides detailed error messages if the file cannot be read. Use this tool when you need to examine the contents of a single file. Only works within allowed directories.",
    "parameters": {
      "type": "object",
      "properties": {
        "path": {
          "type": "string"
        }
      },
      "required": [
        "path"
      ],
      "additionalProperties": false,
      "$schema": "http://json-schema.org/draft-07/schema#"
    },
-    "mcp": true
+    "mcp": "fs"
  }
...
```