### PR TITLE
feat(agents): json-viewer use jq cli other than node-jq module

### DIFF
--- a/agents/json-viewer/package.json
+++ b/agents/json-viewer/package.json
@@ -1,7 +1,6 @@
 {
   "dependencies": {
     "@inquirer/input": "^4.0.2",
-    "json-schema-generator": "^2.0.6",
-    "node-jq": "^6.0.1"
+    "json-schema-generator": "^2.0.6"
   }
 }


### PR DESCRIPTION
json-viewer depends on the node-jq package, but it requires downloading the jq binary from the internet and has limited platform support. After this PR merged, json-viwer will rely on the jq already installed on the platform, which is more convenient and  compatible with more platforms.

relate to #159 