### PR TITLE
fixes MCP servers never coming up on windows

### DIFF
--- a/scripts/mcp.sh
+++ b/scripts/mcp.sh
@@ -19,13 +19,21 @@ start() {
     mkdir -p "$MCP_DIR"
     index_js="$ROOT_DIR/mcp/bridge/index.js"
     llm_functions_dir="$ROOT_DIR"
+    npm_package_dir="$ROOT_DIR/mcp/bridge"
     if _is_win; then
         index_js="$(cygpath -w "$index_js")"
         llm_functions_dir="$(cygpath -w "$llm_functions_dir")"
+        npm_package_dir="$(cygpath -w "$npm_package_dir")"
     fi
     echo "Start MCP Bridge server..."
-    echo "Install node dependencies..." > "$MCP_LOG_FILE"
-    npm install --prefix "$ROOT_DIR/mcp/bridge" 1>/dev/null 2>> "$MCP_LOG_FILE"
+    echo "Installing dependencies in: $npm_package_dir" > "$MCP_LOG_FILE"
+    if _is_win; then
+        pushd "$npm_package_dir" > NUL
+        npm install 1>/dev/null 2>> "$MCP_LOG_FILE"
+        popd > NUL
+    else
+        npm install --prefix "$npm_package_dir" 1>/dev/null 2>> "$MCP_LOG_FILE"
+    fi
     nohup node "$index_js" "$llm_functions_dir" >> "$MCP_LOG_FILE" 2>&1 &
     wait-for-server
     echo "Merge MCP tools into functions.json"


### PR DESCRIPTION
This fixes https://github.com/sigoden/llm-functions/issues/185 MCP server cannot start on Windows

```
PS D:\projects\scratch\llm-functions> argc mcp start
On Windows...
Start MCP Bridge server...
Install node dependencies...
npm_package_dir: D:\projects\scratch\llm-functions\mcp\bridge
npm error code ENOENT
npm error syscall open
npm error path D:\projects\scratch\llm-functions\package.json
npm error errno -4058
npm error enoent Could not read package.json: Error: ENOENT: no such file or directory, open 'D:\projects\scratch\llm-functions\package.json'
npm error enoent This is related to npm not being able to find a file.
npm error enoent
npm error A complete log of this run can be found in: C:\Users\Sid31\AppData\Local\npm-cache\_logs\2025-05-08T01_23_52_939Z-debug-0.log
```